### PR TITLE
Add mapping to make 'cxx' work linewise

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -112,3 +112,4 @@ nnoremap <silent> <Plug>ExchangeClear :<C-u>call <SID>exchange_clear()<CR>
 nmap cx <Plug>Exchange
 vmap cx <Plug>Exchange
 nmap cxc <Plug>ExchangeClear
+nmap cxx cx_


### PR DESCRIPTION
Just like `guu` lowercases the current line, `cxx` should select the current line for exchanging.
