### PR TITLE
Fix typos in documentation.

### DIFF
--- a/doc/exchange.txt
+++ b/doc/exchange.txt
@@ -9,9 +9,9 @@ INTRODUCTION                                    *exchange*
 
 This plugin provides |operators| for exchanging text in two places. The main
 operator is |cx|, which is used in pairs. Each time it is used, it defines a
-region of text to to be exchanged; on the second use, the two defined regions
-are exchanged. If one region is fully contained within the other, it replaces
-the containing region.
+region of text to be exchanged; on the second use, the two defined regions are
+exchanged. If one region is fully contained within the other, it replaces the
+containing region.
 
 MAPPINGS                                        *exchange-mappings*
 
@@ -32,7 +32,7 @@ cxc                     Clear any defined region of text (previously defined
                         by a |cx| command)
 
                                                 *v_X* *exchange-visual*
-{visal}X                Can be used in |visual-mode|.
+{Visual}X               Can be used in |visual-mode|.
 
 EXAMPLES                                        *exchange-examples*
 


### PR DESCRIPTION
Hello! I just found your very nice plugin. I have developed a similar one ([SwapText plugin](http://www.vim.org/scripts/script.php?script_id=4971); just released on vim.org) that works by deleting, and only then invoking a custom operator. I think they can actually complement each other.

While trying out yours, I noticed some minor issues. I hope you'll accept these pull requests, and keep on maintaining this!

-- cheers, ingo
