### PR TITLE
Do not create a select mode default mapping.

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -210,6 +210,6 @@ if exists('g:exchange_no_mappings')
 endif
 
 call s:create_map('n', 'cx', '<Plug>(Exchange)')
-call s:create_map('v', 'X', '<Plug>(Exchange)')
+call s:create_map('x', 'X', '<Plug>(Exchange)')
 call s:create_map('n', 'cxc', '<Plug>(ExchangeClear)')
 call s:create_map('n', 'cxx', '<Plug>(ExchangeLine)')


### PR DESCRIPTION
In select mode (the variant of visual mode), any printable characters should override the selection (see below `:help v_CTRL-G`), so no such mappings should exist. Limit the default visual mode mapping to visual mode (`:xmap`). (The `<Plug>(Exchange)` can and should be defined for both.)
