### PR TITLE
Support :set selection=exclusive

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -32,28 +32,33 @@ endfunction
 function! s:exchange_get(type, vis)
 	let reg = getreg('"')
 	let reg_mode = getregtype('"')
-	let selection = &selection
-	let &selection = 'inclusive'
 	if a:vis
 		let type = a:type
 		let [start, end] = s:store_pos("'<", "'>")
-		silent exe "normal! `<" . a:type . "`>y"
-	elseif a:type == 'line'
-		let type = 'V'
-		let [start, end] = s:store_pos("'[", "']")
-		silent exe "normal! '[V']y"
-	elseif a:type == 'block'
-		let type = "\<C-V>"
-		let [start, end] = s:store_pos("'[", "']")
-		silent exe "normal! `[\<C-V>`]y"
+		silent normal! gvy
+		if &selection ==# 'exclusive' && start != end
+			let end[2] -= len(matchstr(@@, '\_.$'))
+		endif
 	else
-		let type = 'v'
-		let [start, end] = s:store_pos("'[", "']")
-		silent exe "normal! `[v`]y"
+		let selection = &selection
+		let &selection = 'inclusive'
+		if a:type == 'line'
+			let type = 'V'
+			let [start, end] = s:store_pos("'[", "']")
+			silent exe "normal! '[V']y"
+		elseif a:type == 'block'
+			let type = "\<C-V>"
+			let [start, end] = s:store_pos("'[", "']")
+			silent exe "normal! `[\<C-V>`]y"
+		else
+			let type = 'v'
+			let [start, end] = s:store_pos("'[", "']")
+			silent exe "normal! `[v`]y"
+		endif
+		let &selection = selection
 	endif
 	let text = getreg('@')
 	call setreg('"', reg, reg_mode)
-	let &selection = selection
 	return [text, type, start, end]
 endfunction
 


### PR DESCRIPTION
With this, the `'>` mark points to after the end of the selection.
- Do not change the `'selection'` value when the plugin is triggered from visual mode, so that we can grab the original selection.
- Simplification: `gv` can be used instead of `"`<" . a:type . "`>"` to restore the original selection. This also deals with blockwise-to-end in all cases.
- For the highlighting, the end position must be corrected. Since these are byte indices, we cannot just decrement by 1, but have to subtract the length of the last selected character!
