### PR TITLE
Fix detection of re-indent setting and fix incorrect setline calls when re-indenting

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -70,7 +70,7 @@ function! s:reindent(start, lines, new_indent)
 	if s:get_setting('exchange_indent', 1) == '=='
 		let lnum = nextnonblank(a:start)
 		if lnum == 0 || lnum > a:start + a:lines - 1
-				return
+			return
 		endif
 		let line = getline(lnum)
 		execute "silent normal! " . lnum . "G=="

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -69,6 +69,9 @@ endfunction
 function! s:reindent(start, lines, new_indent)
 	if s:get_setting('exchange_indent', 1) == '=='
 		let lnum = nextnonblank(a:start)
+		if lnum == 0 || lnum > a:start + a:lines - 1
+				return
+		endif
 		let line = getline(lnum)
 		execute "silent normal! " . lnum . "G=="
 		let new_indent = matchstr(getline(lnum), '^\s*')

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -8,7 +8,8 @@ function! s:exchange(x, y, reverse, expand)
 	let selection = &selection
 	set selection=inclusive
 
-	let indent = s:get_setting('exchange_indent', 1) != 0 && a:x.type ==# 'V' && a:y.type ==# 'V'
+	" Compare using =~ because "'==' != 0" returns 0
+	let indent = s:get_setting('exchange_indent', 1) !~ 0 && a:x.type ==# 'V' && a:y.type ==# 'V'
 
 	if indent
 		let xindent = matchstr(getline(nextnonblank(a:y.start.line)), '^\s*')


### PR DESCRIPTION
The first change here is a little weird. I should have put the comment I added here to the original commit, but I was using `!~` instead of `!=` intentionally because `'==' != 0` unintuitively evaluates to `0` in Vim so setting `g:exchange_indent = '=='` is treated like `g:exchange_indent = 0`.

The second change fixes a bug in the re-indentation code which assumes there is a non-blank line in the exchange region which causes, for example,
```
abc

def
```
to change to
```
abc
abc
def
```
when exchanging the first two lines with `g:exchange_indent = '=='`.