### PR TITLE
Fix calling setline on wrong line in reindent

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -75,7 +75,7 @@ function! s:reindent(start, lines, new_indent)
 		let line = getline(lnum)
 		execute "silent normal! " . lnum . "G=="
 		let new_indent = matchstr(getline(lnum), '^\s*')
-		call setline(a:start, line)
+		call setline(lnum, line)
 	else
 		let new_indent = a:new_indent
 	endif


### PR DESCRIPTION
The code I wrote calls `setline` on the wrong line if `a:start` is different from `lnum`. Don't know how I missed that.