### PR TITLE
correct link to zsh port

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ other text editors.
 
 [emacs]: https://melpa.org/#/evil-exchange
 [atom]: https://atom.io/packages/vim-mode-plus-exchange
-[zsh]: https://github.com/okapia/vim-exchange
+[zsh]: https://github.com/okapia/zsh-viexchange
 [dd]: https://github.com/Dewdrops
 [dk]: https://github.com/dillonkearns
 [ok]: https://github.com/okapia


### PR DESCRIPTION
I'm very sorry, it seems I made the link point to the fork of the vim plugin rather than the zsh plugin. Im my defence, the URLs look rather similar. Seems it was too late to adjust the first pull request so I've had to make a fresh one. Sorry for the hassle.

I'd heartily recommend zsh, especially for it's vi mode (text objects, surround, visual mode are all there).