### PR TITLE
Persist highlighting on color scheme change

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -333,6 +333,7 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
+execute 'highlight default link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -339,13 +339,13 @@ vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)
 nnoremap <silent> <Plug>(ExchangeClear) :<C-u>call <SID>exchange_clear()<CR>
 nnoremap <silent> <expr> <Plug>(ExchangeLine) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@_'
 
-command! XchangeHighlightToggle call s:highlight_toggle()
-command! XchangeHighlightEnable call s:highlight_toggle(1)
-command! XchangeHighlightDisable call s:highlight_toggle(0)
+command! -bar XchangeHighlightToggle call s:highlight_toggle()
+command! -bar XchangeHighlightEnable call s:highlight_toggle(1)
+command! -bar XchangeHighlightDisable call s:highlight_toggle(0)
 
 XchangeHighlightEnable
 
-command! XchangeClear call s:exchange_clear()
+command! -bar XchangeClear call s:exchange_clear()
 
 if exists('g:exchange_no_mappings')
 	finish

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -333,7 +333,7 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
-execute 'highlight default link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
+highlight default link _exchange_region ExchangeRegion
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -235,7 +235,15 @@ function! s:highlight_toggle(...)
 	else
 		let s:enable_highlighting = !s:enable_highlighting
 	endif
-	execute 'highlight link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
+	augroup vim_exchange
+		autocmd!
+		if s:enable_highlighting
+			autocmd ColorScheme * highlight link _exchange_region ExchangeRegion
+		else
+			highlight link _exchange_region None
+		endif
+	augroup END
+	doautocmd vim_exchange ColorScheme
 endfunction
 
 " Return < 0 if x comes before y in buffer,

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -333,7 +333,6 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
-highlight default link _exchange_region ExchangeRegion
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>


### PR DESCRIPTION
Well-written Vim color schemes run the command `:highlight clear` to remove the highlight groups set by a previous color scheme. Unfortunately, this also removes the internal highlight group set by vim-exchange, effectively disabling vim-exchange's highlighting, and running `:XchangeHighlightToggle` does not reenable the plugin's highlighting, as demonstrated in the asciinema below:

[![asciicast](https://asciinema.org/a/HjWoNU00pEpo5oFPDMxsZ3ZUf.svg)](https://asciinema.org/a/HjWoNU00pEpo5oFPDMxsZ3ZUf)

In this pull request, this is fixed by adding an `autocmd` to link the `_exchange_region` highlight group back to `ExchangeRegion` when the colorscheme is changed and the highlighting is enabled.

## Alternatives considered

### [Toggle highlighting twice](kloKenPhantasie@06355a246ccd7a0a00e432d331b61770f6f85bfb)

I have rejected this approach for 2 reasons:
- #51 must be merged first, otherwise changing the color schemes raises the following error:
  ```
  Error detected while processing ColorScheme Autocommands for "*":
  E488: Trailing characters: | XchangeHighlightToggle: XchangeHighlightToggle | XchangeHighlightToggle
  ```
- It feels like a hack to me.