### PR TITLE
fix: highlighting is lost when colorscheme is changed

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -325,7 +325,7 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
-execute 'highlight default link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
+highlight default link _exchange_region ExchangeRegion
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -325,6 +325,7 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
+execute 'highlight default link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>


### PR DESCRIPTION
New vim restores default highlight links, but fails to do it when there is no default link in the first place.

Without this fix, vim-exchange looses highlighting after `:colorscheme ...`

Relates to https://github.com/vim/vim/pull/6970