### PR TITLE
Persist highlighting status when changing color schemes

### DIFF
--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -235,7 +235,15 @@ function! s:highlight_toggle(...)
 	else
 		let s:enable_highlighting = !s:enable_highlighting
 	endif
-	execute 'highlight link _exchange_region' (s:enable_highlighting ? 'ExchangeRegion' : 'None')
+	augroup vim_exchange
+		autocmd!
+		if s:enable_highlighting
+			autocmd ColorScheme * highlight link _exchange_region ExchangeRegion
+		else
+			highlight link _exchange_region None
+		endif
+	augroup END
+	doautocmd vim_exchange ColorScheme
 endfunction
 
 " Return < 0 if x comes before y in buffer,

--- a/plugin/exchange.vim
+++ b/plugin/exchange.vim
@@ -333,7 +333,6 @@ function! s:get_setting(setting, default)
 endfunction
 
 highlight default link ExchangeRegion IncSearch
-highlight default link _exchange_region ExchangeRegion
 
 nnoremap <silent> <expr> <Plug>(Exchange) ':<C-u>set operatorfunc=<SID>exchange_set<CR>'.(v:count1 == 1 ? '' : v:count1).'g@'
 vnoremap <silent> <Plug>(Exchange) :<C-u>call <SID>exchange_set(visualmode(), 1)<CR>


### PR DESCRIPTION
Before #53, the highlighting of exchange regions was lost when the color scheme is changed, ignoring the user's preference; this bug was caused by the execution of `:highlight clear` at the beginning of the color scheme, losing the link between the internal `_exchange_region` highlight group and the `ExchangeRegion` group. #53 fixed this bug by defaulting the link, making it resilient to color scheme changes.

However, this fix introduced the opposite bug; when changing the color scheme, the highlighting of exchange regions is always enabled, regardless of the user's preference, and `:XchangeHighlightToggle` fails to disable it, as demonstrated in the video below:

https://user-images.githubusercontent.com/28897513/102714182-39c6f080-42cd-11eb-816a-00a68bc1f4ef.mov

In this pull request, these issues are fixed by adding an `autocmd` restoring the link between `_exchange_region` and `ExchangeRegion` every time the color scheme changes if the highlighting is enabled.

The changes introduced in #53 are reverted, since they conflict with those introduced by this fix.

A follow-up on #52.

## Alternatives considered
### [Toggle highlighting twice](https://github.com/kloKenPhantasie/vim-exchange/tree/toggle-hl-twice-on-cs-change)
While simpler than the changes introduced in this pull request, I rejected this approach because it feels like a hack to me.

### [Keep existing behavior, but set `s:enable_highlighting` to a true value](https://github.com/kloKenPhantasie/vim-exchange/tree/reset-hl-on-cs-change)
I rejected this approach since it does not honor the user's preference.